### PR TITLE
37 fetch and show the agg data for current device on device detail screen

### DIFF
--- a/app/src/main/java/com/ifpe/edu/br/model/repository/Repository.kt
+++ b/app/src/main/java/com/ifpe/edu/br/model/repository/Repository.kt
@@ -44,23 +44,23 @@ class Repository private constructor(context: Context) {
     private val airPowerServerConnection =
         ConnectionManager.getInstance().getConnectionById(AirPowerServerConnectionContractImpl)
     private val airPowerServerMgr = AirPowerServerManager(airPowerServerConnection)
+
     private val _devicesSummary = MutableStateFlow<List<DeviceSummary>>(emptyList())
-
     val devicesSummary: StateFlow<List<DeviceSummary>> get() = _devicesSummary
+
     private val _alarmInfo = MutableStateFlow<List<AlarmInfo>>(emptyList())
-
     val alarmInfo: StateFlow<List<AlarmInfo>> = _alarmInfo.asStateFlow()
-    private val _allDevicesMetricsWrapper = MutableStateFlow(getEmptyAllDevicesMetricsWrapper())
 
+    private val _allDevicesMetricsWrapper = MutableStateFlow(getEmptyAllDevicesMetricsWrapper())
     val allDevicesMetricsWrapper: StateFlow<AllMetricsWrapper> =
         _allDevicesMetricsWrapper.asStateFlow()
+
     private val _dashBoardsMetricsWrapper =
         MutableStateFlow(listOf(getEmptyAllDevicesMetricsWrapper()))
-
     val dashBoardsMetricsWrapper: StateFlow<List<AllMetricsWrapper>> =
         _dashBoardsMetricsWrapper.asStateFlow()
-    private val _notification = MutableStateFlow(getEmptyNotification())
 
+    private val _notification = MutableStateFlow(getEmptyNotification())
     private val notification: StateFlow<List<NotificationItem>> = _notification.asStateFlow()
 
     companion object {

--- a/app/src/main/java/com/ifpe/edu/br/model/repository/remote/api/AirPowerServerAPIService.kt
+++ b/app/src/main/java/com/ifpe/edu/br/model/repository/remote/api/AirPowerServerAPIService.kt
@@ -3,7 +3,6 @@ package com.ifpe.edu.br.model.repository.remote.api
 import com.ifpe.edu.br.model.repository.remote.dto.AlarmInfo
 import com.ifpe.edu.br.model.repository.remote.dto.AllMetricsWrapper
 import com.ifpe.edu.br.model.repository.remote.dto.DeviceSummary
-import com.ifpe.edu.br.model.repository.remote.dto.TelemetryAggregationResponse
 import com.ifpe.edu.br.model.repository.remote.dto.agg.AggDataWrapperResponse
 import com.ifpe.edu.br.model.repository.remote.dto.auth.Token
 import com.ifpe.edu.br.model.repository.remote.dto.user.ThingsBoardUser
@@ -31,9 +30,6 @@ interface AirPowerServerAPIService {
 
     @GET("/api/v1/user/me")
     suspend fun getCurrentUser(): ThingsBoardUser
-
-    @POST("/test/api/v1/devices/telemetry/aggregate")
-    suspend fun getAggregatedTelemetry(@Body requestBody: RequestBody): TelemetryAggregationResponse
 
     @GET("/api/v1/user/{userId}/devices-summary")
     suspend fun getDeviceSummariesForUser(

--- a/app/src/main/java/com/ifpe/edu/br/model/repository/remote/api/AirPowerServerManager.kt
+++ b/app/src/main/java/com/ifpe/edu/br/model/repository/remote/api/AirPowerServerManager.kt
@@ -1,26 +1,22 @@
 package com.ifpe.edu.br.model.repository.remote.api
 
 import com.google.gson.Gson
-import com.ifpe.edu.br.model.repository.model.TelemetryDataWrapper
 import com.ifpe.edu.br.model.repository.persistence.manager.JWTManager
 import com.ifpe.edu.br.model.repository.remote.dto.AlarmInfo
 import com.ifpe.edu.br.model.repository.remote.dto.AllMetricsWrapper
 import com.ifpe.edu.br.model.repository.remote.dto.DeviceSummary
-import com.ifpe.edu.br.model.repository.remote.dto.TelemetryAggregationResponse
 import com.ifpe.edu.br.model.repository.remote.dto.agg.AggDataWrapperResponse
 import com.ifpe.edu.br.model.repository.remote.dto.agg.AggregationRequest
 import com.ifpe.edu.br.model.repository.remote.dto.auth.AuthUser
 import com.ifpe.edu.br.model.repository.remote.dto.auth.Token
 import com.ifpe.edu.br.model.repository.remote.dto.error.ErrorCode
 import com.ifpe.edu.br.model.repository.remote.dto.user.ThingsBoardUser
-import com.ifpe.edu.br.model.repository.remote.query.AggregatedTelemetryQuery
 import com.ifpe.edu.br.model.repository.remote.query.RefreshTokenQuery
 import com.ifpe.edu.br.model.util.AirPowerLog
 import com.ifpe.edu.br.model.util.ResultWrapper
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody
 import retrofit2.Retrofit
-import java.util.UUID
 
 
 // Trabalho de conclusão de curso - IFPE 2025
@@ -81,16 +77,6 @@ class AirPowerServerManager(connection: Retrofit) {
         return safeApiCall { apiService.getCurrentUser() }
     }
 
-    suspend fun getAggregatedTelemetry(
-        query: AggregatedTelemetryQuery
-    ): ResultWrapper<TelemetryAggregationResponse> {
-        if (AirPowerLog.ISVERBOSE) AirPowerLog.d(TAG, "getAggregatedTelemetry()")
-        val queryJson = Gson().toJson(query)
-        val mediaType = "application/json; charset=utf-8".toMediaTypeOrNull()
-        val requestBody = RequestBody.create(mediaType, queryJson)
-        return safeApiCall { apiService.getAggregatedTelemetry(requestBody) }
-    }
-
     suspend fun getDeviceSummariesForUser(
         user: ThingsBoardUser
     ): ResultWrapper<List<DeviceSummary>> {
@@ -108,40 +94,13 @@ class AirPowerServerManager(connection: Retrofit) {
         return safeApiCall { apiService.getDevicesMetricsWrapper(groupID) }
     }
 
-    suspend fun getDeviceMetricsWrapperById(id: UUID): ResultWrapper<TelemetryDataWrapper> {
-        if (AirPowerLog.ISVERBOSE) AirPowerLog.d(TAG, "getDevicesMetricsWrapper()")
-        val result = safeApiCall { apiService.getDevicesMetricsWrapper(id.toString()) }
-        return when (result) {
-            is ResultWrapper.Success -> {
-                if (result.value.isEmpty()) {
-                    return ResultWrapper.ApiError(ErrorCode.TB_GENERIC_ERROR)
-                }
-                val allMetricsWrapper = result.value[0]
-                val deviceConsumptionSet = allMetricsWrapper.deviceConsumptionSet
-                val label = allMetricsWrapper.label
-                val telemetryDataWrapper = TelemetryDataWrapper(label, deviceConsumptionSet)
-                return ResultWrapper.Success(telemetryDataWrapper)
-            }
-
-            is ResultWrapper.ApiError -> {
-                ResultWrapper.ApiError(result.errorCode)
-            }
-
-            ResultWrapper.NetworkError -> {
-                ResultWrapper.NetworkError
-            }
-
-            ResultWrapper.Empty -> {
-                ResultWrapper.Empty
-            }
-        }
-    }
-
     suspend fun getDeviceAggregatedDataWrapper(
         request: AggregationRequest
     ): ResultWrapper<AggDataWrapperResponse> {
-        if (AirPowerLog.ISVERBOSE) AirPowerLog.d(TAG, "getDeviceAggregatedDataWrapper(): " +
-                "request: $request")
+        if (AirPowerLog.ISVERBOSE) AirPowerLog.d(
+            TAG, "getDeviceAggregatedDataWrapper(): " +
+                    "request: $request"
+        )
         val queryJson = Gson().toJson(request)
         val mediaType = "application/json; charset=utf-8".toMediaTypeOrNull()
         val requestBody = RequestBody.create(mediaType, queryJson)

--- a/app/src/main/java/com/ifpe/edu/br/model/util/AirPowerUtil.java
+++ b/app/src/main/java/com/ifpe/edu/br/model/util/AirPowerUtil.java
@@ -16,10 +16,14 @@ import androidx.core.content.res.ResourcesCompat;
 import com.ifpe.edu.br.BuildConfig;
 import com.ifpe.edu.br.R;
 import com.ifpe.edu.br.model.Constants;
+import com.ifpe.edu.br.model.repository.remote.dto.AlarmInfo;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 
 public class AirPowerUtil {
 
@@ -99,5 +103,16 @@ public class AirPowerUtil {
                 R.anim.enter_from_right,
                 R.anim.exit_to_left
         );
+    }
+
+    public static List<AlarmInfo> getAlarmInfoForDeviceId(
+            UUID deviceId, List<AlarmInfo> alarmInfoSet) {
+        List<AlarmInfo> resultSet = new ArrayList<>();
+        for (AlarmInfo info : alarmInfoSet) {
+            if (info.getOriginator().getId().equals(deviceId)) {
+                resultSet.add(info);
+            }
+        }
+        return resultSet;
     }
 }

--- a/app/src/main/java/com/ifpe/edu/br/view/ui/screens/DeviceDetail.kt
+++ b/app/src/main/java/com/ifpe/edu/br/view/ui/screens/DeviceDetail.kt
@@ -38,6 +38,7 @@ import com.ifpe.edu.br.model.repository.remote.dto.agg.AggregationRequest
 import com.ifpe.edu.br.model.repository.remote.dto.agg.ChartDataWrapper
 import com.ifpe.edu.br.model.repository.remote.dto.agg.TelemetryKey
 import com.ifpe.edu.br.model.repository.remote.dto.agg.TimeInterval
+import com.ifpe.edu.br.model.util.AirPowerUtil
 import com.ifpe.edu.br.model.util.ResultWrapper
 import com.ifpe.edu.br.view.ui.components.AlarmCardInfo
 import com.ifpe.edu.br.view.ui.components.EmptyStateCard
@@ -62,7 +63,6 @@ fun DeviceDetailScreen(
     mainViewModel: AirPowerViewModel
 ) {
 
-
     val deviceDetailAddRequest = AggregationRequest(
         devicesIds = listOf(deviceId.toString()),
         aggStrategy = AggStrategy.AVG,
@@ -77,7 +77,7 @@ fun DeviceDetailScreen(
         mainViewModel.getAggregatedDataState(deviceDetailAddRequest).collectAsState()
     val scrollState = rememberScrollState()
     val device = mainViewModel.getDeviceById(deviceId.toString())
-    val alarmInfoSet = mainViewModel.getAlarmInfoSet().collectAsState(initial = emptyList())
+    val alarmInfoSet = mainViewModel.getAlarmInfoSet().collectAsState()
 
     LaunchedEffect(deviceId) {
         mainViewModel.fetchAggregatedData(deviceDetailAddRequest)
@@ -93,7 +93,8 @@ fun DeviceDetailScreen(
             DeviceConsumptionCard(
                 aggregationState = aggregationState.value
             )
-            AlarmsCard(alarmInfoSet.value)
+
+            AlarmsCard(AirPowerUtil.getAlarmInfoForDeviceId(deviceId, alarmInfoSet.value))
         }
     )
 }
@@ -123,6 +124,7 @@ private fun AlarmsCard(
             }
 
             Spacer(modifier = Modifier.padding(vertical = 4.dp))
+
 
             DeviceDetailAlarmGrid(alarmCards) {
                 Toast.makeText(

--- a/app/src/main/java/com/ifpe/edu/br/view/ui/screens/DeviceDetail.kt
+++ b/app/src/main/java/com/ifpe/edu/br/view/ui/screens/DeviceDetail.kt
@@ -29,13 +29,18 @@ import com.ifpe.edu.br.common.components.CustomBarChart
 import com.ifpe.edu.br.common.components.CustomCard
 import com.ifpe.edu.br.common.components.CustomColumn
 import com.ifpe.edu.br.common.components.CustomText
-import com.ifpe.edu.br.model.Constants
 import com.ifpe.edu.br.model.repository.model.HomeScreenAlarmSummaryCard
 import com.ifpe.edu.br.model.repository.remote.dto.AlarmInfo
 import com.ifpe.edu.br.model.repository.remote.dto.DeviceSummary
+import com.ifpe.edu.br.model.repository.remote.dto.agg.AggDataWrapperResponse
+import com.ifpe.edu.br.model.repository.remote.dto.agg.AggStrategy
+import com.ifpe.edu.br.model.repository.remote.dto.agg.AggregationRequest
+import com.ifpe.edu.br.model.repository.remote.dto.agg.ChartDataWrapper
+import com.ifpe.edu.br.model.repository.remote.dto.agg.TelemetryKey
+import com.ifpe.edu.br.model.repository.remote.dto.agg.TimeInterval
+import com.ifpe.edu.br.model.util.ResultWrapper
 import com.ifpe.edu.br.view.ui.components.AlarmCardInfo
 import com.ifpe.edu.br.view.ui.components.EmptyStateCard
-import com.ifpe.edu.br.view.ui.components.LoadingCard
 import com.ifpe.edu.br.view.ui.components.getStatusColor
 import com.ifpe.edu.br.view.ui.theme.app_default_solid_background_light
 import com.ifpe.edu.br.view.ui.theme.tb_primary_light
@@ -57,13 +62,26 @@ fun DeviceDetailScreen(
     mainViewModel: AirPowerViewModel
 ) {
 
-    LaunchedEffect(Unit) {
-        mainViewModel.fetchChartDataWrapper(deviceId)
-    }
 
+    val deviceDetailAddRequest = AggregationRequest(
+        devicesIds = listOf(deviceId.toString()),
+        aggStrategy = AggStrategy.AVG,
+        aggKey = TelemetryKey.POWER,
+        timeIntervalWrapper = getTimeWrapper(
+            System.currentTimeMillis(),
+            TimeInterval.MONTH
+        )
+    )
+
+    val aggregationState =
+        mainViewModel.getAggregatedDataState(deviceDetailAddRequest).collectAsState()
     val scrollState = rememberScrollState()
     val device = mainViewModel.getDeviceById(deviceId.toString())
     val alarmInfoSet = mainViewModel.getAlarmInfoSet().collectAsState(initial = emptyList())
+
+    LaunchedEffect(deviceId) {
+        mainViewModel.fetchAggregatedData(deviceDetailAddRequest)
+    }
 
     CustomColumn(
         modifier = Modifier
@@ -72,7 +90,9 @@ fun DeviceDetailScreen(
         alignmentStrategy = CommonConstants.Ui.ALIGNMENT_CENTER,
         layouts = listOf {
             DeviceInfoCard(device)
-            DeviceConsumptionCard(mainViewModel)
+            DeviceConsumptionCard(
+                aggregationState = aggregationState.value
+            )
             AlarmsCard(alarmInfoSet.value)
         }
     )
@@ -137,12 +157,8 @@ private fun AlarmsCard(
 
 @Composable
 private fun DeviceConsumptionCard(
-    viewModel: AirPowerViewModel
+    aggregationState: ResultWrapper<AggDataWrapperResponse>
 ) {
-    val chartDataWrapper = viewModel.getChartDataWrapper().collectAsState()
-    val deviceMetricState =
-        viewModel.uiStateManager.observeUIState(Constants.UIStateKey.DEVICE_METRICS_KEY)
-
     CustomCard(
         paddingStart = 15.dp,
         paddingEnd = 15.dp,
@@ -163,18 +179,17 @@ private fun DeviceConsumptionCard(
                         )
                     }
                     Spacer(modifier = Modifier.padding(vertical = 12.dp))
-                    when (deviceMetricState.value.state) {
-                        Constants.UIState.STATE_LOADING -> {
-                            LoadingCard()
-                        }
 
-                        Constants.UIState.STATE_SUCCESS -> {
-                            CustomBarChart(dataWrapper = chartDataWrapper.value)
-                        }
-
-                        else -> {
-                            EmptyStateCard()
-                        }
+                    if (aggregationState is ResultWrapper.Success) {
+                        CustomBarChart(
+                            height = 300.dp,
+                            dataWrapper = ChartDataWrapper(
+                                aggregationState.value.chartDataWrapper.label,
+                                aggregationState.value.chartDataWrapper.entries
+                            )
+                        )
+                    } else {
+                        EmptyStateCard()
                     }
                     Spacer(modifier = Modifier.padding(vertical = 4.dp))
                 }

--- a/app/src/main/java/com/ifpe/edu/br/view/ui/screens/DeviceDetail.kt
+++ b/app/src/main/java/com/ifpe/edu/br/view/ui/screens/DeviceDetail.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -94,7 +95,10 @@ fun DeviceDetailScreen(
                 aggregationState = aggregationState.value
             )
 
-            AlarmsCard(AirPowerUtil.getAlarmInfoForDeviceId(deviceId, alarmInfoSet.value))
+            val deviceAlarms = remember(deviceId, alarmInfoSet.value) {
+                AirPowerUtil.getAlarmInfoForDeviceId(deviceId, alarmInfoSet.value)
+            }
+            AlarmsCard(deviceAlarms)
         }
     )
 }

--- a/app/src/main/java/com/ifpe/edu/br/view/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ifpe/edu/br/view/ui/screens/HomeScreen.kt
@@ -127,7 +127,6 @@ fun HomeScreen(
 fun SummaryCardCardBoard(
     resultWrapper: ResultWrapper<AggDataWrapperResponse>,
     viewModel: AirPowerViewModel
-
 ) {
     val aggKey = Constants.UIStateKey.AGG_DATA_KEY
     val aggDataState = viewModel.uiStateManager.observeUIState(aggKey).collectAsState()
@@ -192,7 +191,7 @@ private fun AlarmsSummaryCardCardBoard(
             ) {
                 CustomText(
                     color = tb_primary_light,
-                    text = "Alarmes do dispositivo",
+                    text = "Meus alarmes",
                     fontSize = 20.sp
                 )
             }

--- a/app/src/main/java/com/ifpe/edu/br/viewmodel/AirPowerViewModel.kt
+++ b/app/src/main/java/com/ifpe/edu/br/viewmodel/AirPowerViewModel.kt
@@ -295,37 +295,6 @@ class AirPowerViewModel(
         }
     }
 
-    fun getChartDataWrapper(): StateFlow<TelemetryDataWrapper> {
-        return repository.chartDataWrapper
-    }
-
-    fun fetchChartDataWrapper(id: UUID): Job {
-        return viewModelScope.launch {
-            val startTime = System.currentTimeMillis()
-            val sessionStateKey = Constants.UIStateKey.SESSION
-            val deviceMetricKeys = Constants.UIStateKey.DEVICE_METRICS_KEY
-            uiStateManager.setUIState(deviceMetricKeys, UIState(Constants.UIState.STATE_LOADING))
-            when (val resultWrapper = repository.retrieveChartDataWrapper(id)) {
-                is ResultWrapper.ApiError -> {
-                    handleApiError(resultWrapper.errorCode, sessionStateKey)
-                    handleApiError(resultWrapper.errorCode, deviceMetricKeys)
-                }
-
-                is ResultWrapper.NetworkError -> {
-                    handleNetworkError(sessionStateKey)
-                    handleNetworkError(deviceMetricKeys)
-                }
-
-                is ResultWrapper.Success<*> -> {
-                    handleSuccess(sessionStateKey)
-                    handleSuccess(deviceMetricKeys)
-                }
-
-                ResultWrapper.Empty -> {}
-            }
-        }
-    }
-
     fun fetchAllDashboardsMetricsWrapper(): Job {
         return viewModelScope.launch {
             val startTime = System.currentTimeMillis()


### PR DESCRIPTION
Highlights
Aggregated Data Integration: The device detail screen now fetches and displays aggregated power consumption data for the specific device being viewed. This replaces a previous, more generic chart data fetching mechanism.
Device-Specific Alarm Filtering: Alarms shown on the device detail screen are now filtered to display only those originating from the current device, improving relevance for the user.
Codebase Modernization and Cleanup: Significant legacy code related to TelemetryDataWrapper and older aggregation methods has been removed from the Repository, AirPowerServerAPIService, AirPowerServerManager, and AirPowerViewModel, streamlining the data layer.